### PR TITLE
dioryVideoGenerator refactor

### DIFF
--- a/api/import.ts
+++ b/api/import.ts
@@ -70,7 +70,7 @@ async function generateTypeSpecificDiory(
       return imageDiory
     case 'video':
       // TODO: videoDiory can't be typed as Diory as it doesn't have id yet...
-      const videoDiory = await dioryVideoGenerator(fileContent, filePath, contentUrl)
+      const videoDiory = await dioryVideoGenerator(filePath, contentUrl)
       videoDiory.typeSpecificDiory.data[0]['encodingFormat'] = encodingFormat.mime
       return videoDiory
     case 'audio':

--- a/generators/video/ffmpeg-output-parser.ts
+++ b/generators/video/ffmpeg-output-parser.ts
@@ -1,0 +1,26 @@
+function parseDate(outputString: string) {
+  return outputString.match(/(?<=creation_time\s\s\s:\s).*/)
+}
+
+function parseLatlng(outputString: string) {
+  return outputString.match(/(?<=location\s\s\s\s\s\s\s\s:\s\+).{16}/)
+}
+
+function parseDuration(outputString: string) {
+  return outputString.match(/(?<=Duration:\s).{11}/)
+}
+
+function parseFfmpegOutput(outputString: string) {
+  const date = parseDate(outputString)
+  const latlng = parseLatlng(outputString)
+  const duration = parseDuration(outputString)
+  // Hacky way to trim longitude's leading zero
+  const splitter = latlng && latlng[0].match(/\+0/) ? '+0' : '0'
+  return {
+    date: date && date[0],
+    duration: duration && duration[0],
+    latlng: latlng && latlng[0].split(splitter).join(', '),
+  }
+}
+
+export { parseFfmpegOutput, parseDate, parseLatlng, parseDuration }

--- a/generators/video/index.spec.ts
+++ b/generators/video/index.spec.ts
@@ -1,0 +1,24 @@
+import { dioryVideoGenerator } from '.'
+import { generateThumbnail } from './thumbnailer'
+
+jest.mock('./thumbnailer')
+const { execFileReturnObjectFixture } = require('./ffmpeg-return-object-fixture')
+;(generateThumbnail as jest.Mock).mockResolvedValue({
+  thumbnailBuffer: 'some-buffer',
+  ffmpegOutput: execFileReturnObjectFixture.stderr,
+})
+
+describe('dioryVideoGenerator', () => {
+  beforeEach(() => {})
+
+  it('works', async () => {
+    const { thumbnailBuffer, typeSpecificDiory } = await dioryVideoGenerator(
+      'some-path',
+      'some-content-url',
+    )
+    expect(thumbnailBuffer).toEqual('some-buffer')
+    expect(typeSpecificDiory.date).toEqual('2020-06-30T08:18:22.000000Z')
+    expect(typeSpecificDiory.latlng).toEqual('65.4752, 27.9785')
+    expect(typeSpecificDiory.data[0].duration).toEqual('00:00:34.56')
+  })
+})

--- a/generators/video/index.ts
+++ b/generators/video/index.ts
@@ -1,23 +1,19 @@
 import { generateThumbnail } from './thumbnailer'
+import { parseFfmpegOutput } from './ffmpeg-output-parser'
 
 async function dioryVideoGenerator(filePath: string, contentUrl: string) {
   const { thumbnailBuffer, ffmpegOutput } = await generateThumbnail(filePath)
-
-  const creationTime = ffmpegOutput.match(/(?<=creation_time\s\s\s:\s).*/)
-  const latlng = ffmpegOutput.match(/(?<=location\s\s\s\s\s\s\s\s:\s\+).{16}/)
-  const duration = ffmpegOutput.match(/(?<=Duration:\s).{11}/)
-  // Hacky way to trim longitude's leading zero
-  const splitter = latlng && latlng[0].match(/\+0/) ? '+0' : '0'
+  const { date, latlng, duration } = parseFfmpegOutput(ffmpegOutput)
 
   const typeSpecificDiory = {
-    date: creationTime && creationTime[0],
-    latlng: latlng && latlng[0].split(splitter).join(', '),
+    ...(date && { date }),
+    ...(latlng && { latlng }),
     data: [
       {
         '@context': 'https://schema.org',
         '@type': 'VideoObject',
         contentUrl,
-        duration: duration && duration[0],
+        ...(duration && { duration }),
         encodingFormat: '',
       },
     ],

--- a/generators/video/index.ts
+++ b/generators/video/index.ts
@@ -1,6 +1,6 @@
 import { generateThumbnail } from './thumbnailer'
 
-async function dioryVideoGenerator(fileContent: Buffer, filePath: string, contentUrl: string) {
+async function dioryVideoGenerator(filePath: string, contentUrl: string) {
   const { thumbnailBuffer, ffmpegOutput } = await generateThumbnail(filePath)
 
   const creationTime = ffmpegOutput.match(/(?<=creation_time\s\s\s:\s).*/)


### PR DESCRIPTION
* [Extract ffmpegOutput parsing logic to its own file](https://github.com/DioryMe/diograph-js/commit/5139758da9bf5166c93e3035e7f446757aa71568)
* [First dioryVideoGenerator test: it 'works'](https://github.com/DioryMe/diograph-js/commit/97a53a545f91cdc2ed7b28273578d3914102e494)