### PR TITLE
Validate diograph and rework room initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,11 @@ diory.toJson()
 ### Room
 
 ```
-loadRoom(clients)
-- set room object contents from room.json: connections & diograph
+loadOrInitiateRoom(clients)
+- set room object contents (connections & diograph)
+  - from arguments if given
+  - from room.json if roomClien available
 - initiate connections if proper client is passed
-
-initiateRoom(clients, connections, diographObject)
-- set room object contents from arguments: connections & diograph
 
 addConnection(connection)
 - attach a connection to room

--- a/README.md
+++ b/README.md
@@ -92,9 +92,6 @@ toJson()
 ### Connection
 
 ```
-initiateConnection()
-- set connection object contens from arguments: contentUrls & diograph
-
 addContentUrl(contentId)
 - used when listing a content folder contents to connection
   - in this case content is not added to connection (as it already exists!)

--- a/diograph/diograph.spec.ts
+++ b/diograph/diograph.spec.ts
@@ -203,11 +203,12 @@ describe('diograph', () => {
 
         it('empty diograph is not empty after adding root diory', () => {
           emptyDiograph.addRootDiory()
+          expect(Object.keys(emptyDiograph.diograph).length).toStrictEqual(1)
+          expect(emptyDiograph.diograph['/'].id).toStrictEqual('/')
           expect(emptyDiograph.isEmptyDiograph()).toBe(false)
         })
 
-        it('creates root diory when addDiory', () => {
-          emptyDiograph.addRootDiory()
+        it('creates root diory when addDiory to empty diograph', () => {
           emptyDiograph.addDiory({ id: 'some-id' })
           expect(emptyDiograph.diograph['/'].id).toStrictEqual('/')
           expect(emptyDiograph.diograph['some-id'].id).toStrictEqual('some-id')

--- a/diograph/diograph.spec.ts
+++ b/diograph/diograph.spec.ts
@@ -240,7 +240,8 @@ describe('diograph', () => {
       })
     })
 
-    describe('given diograph with query text diory', () => {
+    // FIXME: Current implementation of queryDiograph() doesn't work with validated diographs
+    describe.skip('given diograph with query text diory', () => {
       beforeEach(() => {
         diograph.initialise({
           '/': {

--- a/diograph/diograph.spec.ts
+++ b/diograph/diograph.spec.ts
@@ -16,9 +16,17 @@ describe('diograph', () => {
 
     beforeEach(() => {
       diographObject = {
+        '/': {
+          id: '/',
+          text: 'root-diory',
+          created: '2022-06-01T07:30:07.991Z',
+          modified: '2022-06-01T07:30:08.003Z',
+        },
         'some-id': {
           id: 'some-id',
           text: 'some-text',
+          created: '2022-06-01T07:30:07.991Z',
+          modified: '2022-06-01T07:30:08.003Z',
         },
       }
       diograph = new Diograph(diographObject)
@@ -31,6 +39,7 @@ describe('diograph', () => {
     describe('when toObject()', () => {
       it('returns diograph object', () => {
         expect(diograph.toObject()).toStrictEqual({
+          '/': expect.objectContaining({ id: '/' }),
           'some-id': expect.objectContaining({ id: 'some-id' }),
         })
       })
@@ -39,9 +48,21 @@ describe('diograph', () => {
     describe('when initialise()', () => {
       describe('given new diory in added diograph object', () => {
         beforeEach(() => {
-          diograph.initialise({
-            'other-id': { id: 'other-id' },
-          })
+          const otherDiographObject = {
+            '/': {
+              id: '/',
+              text: 'root-diory',
+              created: '2022-06-01T07:30:07.991Z',
+              modified: '2022-06-01T07:30:08.003Z',
+            },
+            'other-id': {
+              id: 'other-id',
+              text: 'other-text',
+              created: '2022-06-01T07:30:07.991Z',
+              modified: '2022-06-01T07:30:08.003Z',
+            },
+          }
+          diograph.initialise(otherDiographObject)
         })
 
         it('adds diory to diograph', () => {
@@ -53,6 +74,7 @@ describe('diograph', () => {
         describe('when toObject()', () => {
           it('returns diograph object', () => {
             expect(diograph.toObject()).toStrictEqual({
+              '/': expect.objectContaining({ id: '/' }),
               'other-id': expect.objectContaining({ id: 'other-id' }),
               'some-id': expect.objectContaining({ id: 'some-id' }),
             })
@@ -221,9 +243,17 @@ describe('diograph', () => {
     describe('given diograph with query text diory', () => {
       beforeEach(() => {
         diograph.initialise({
+          '/': {
+            id: '/',
+            text: 'root-diory',
+            created: '2022-06-01T07:30:07.991Z',
+            modified: '2022-06-01T07:30:08.003Z',
+          },
           'query-id': {
             id: 'query-id',
             text: 'query-text',
+            created: '2022-06-01T07:30:07.991Z',
+            modified: '2022-06-01T07:30:08.003Z',
           },
         })
       })

--- a/diograph/diograph.spec.ts
+++ b/diograph/diograph.spec.ts
@@ -190,15 +190,43 @@ describe('diograph', () => {
           expect(diory.text).toBe('some-text')
         })
       })
+
+      describe('when empty diograph', () => {
+        let emptyDiograph: IDiograph
+        beforeEach(() => {
+          emptyDiograph = new Diograph()
+        })
+
+        it('empty diograph is empty diograph', () => {
+          expect(emptyDiograph.isEmptyDiograph()).toBe(true)
+        })
+
+        it('empty diograph is not empty after adding root diory', () => {
+          emptyDiograph.addRootDiory()
+          expect(emptyDiograph.isEmptyDiograph()).toBe(false)
+        })
+
+        it('creates root diory when addDiory', () => {
+          emptyDiograph.addRootDiory()
+          emptyDiograph.addDiory({ id: 'some-id' })
+          expect(emptyDiograph.diograph['/'].id).toStrictEqual('/')
+          expect(emptyDiograph.diograph['some-id'].id).toStrictEqual('some-id')
+          expect(emptyDiograph.diograph['/'].links).toBe(undefined)
+        })
+      })
     })
 
     describe('addDioryAndLink()', () => {
       beforeEach(() => {
-        diory = diograph.addDioryAndLink({ id: 'some-id' })
+        diory = diograph.addDioryAndLink({ id: 'other-id' })
       })
 
       it('adds id', () => {
-        expect(diory.id).toBe('some-id')
+        expect(diory.id).toBe('other-id')
+      })
+
+      it('links diory to root diory', () => {
+        expect(diograph.diograph['/'].links).toStrictEqual([{ id: 'other-id' }])
       })
     })
 

--- a/diograph/diograph.spec.ts
+++ b/diograph/diograph.spec.ts
@@ -192,6 +192,16 @@ describe('diograph', () => {
       })
     })
 
+    describe('addDioryAndLink()', () => {
+      beforeEach(() => {
+        diory = diograph.addDioryAndLink({ id: 'some-id' })
+      })
+
+      it('adds id', () => {
+        expect(diory.id).toBe('some-id')
+      })
+    })
+
     describe('when resetDiograph()', () => {
       it('resets diograph to empty object', () => {
         diograph.resetDiograph()

--- a/diograph/diograph.ts
+++ b/diograph/diograph.ts
@@ -84,7 +84,8 @@ class Diograph implements IDiograph {
 
   addDiory = (dioryObject: IDioryProps | IDioryObject, key?: string): IDiory => {
     if (key !== '/' && this.isEmptyDiograph()) {
-      throw new Error('addDiory: Diograph is empty. Use addRootDiory() to add root diory')
+      console.log('addDiory: Empty diograph detected. Adding root diory.')
+      this.addRootDiory()
     }
 
     if (key) {

--- a/diograph/diograph.ts
+++ b/diograph/diograph.ts
@@ -30,7 +30,9 @@ class Diograph implements IDiograph {
     return this
   }
 
+  // FIXME: Current implementation of queryDiograph() doesn't work with validated diographs
   queryDiograph = (queryDiory: IDioryProps): IDiograph => {
+    throw new Error("queryDiograph() is disabled because it doesn't work with validated diographs")
     const diograph: IDiographObject = queryDiograph(queryDiory, this.toObject())
     return new Diograph(diograph)
   }

--- a/diograph/diograph.ts
+++ b/diograph/diograph.ts
@@ -1,4 +1,11 @@
-import { IDiory, IDioryObject, IDiograph, IDioryProps, IDiographObject } from '../types'
+import {
+  IDiory,
+  IDioryObject,
+  IDiograph,
+  IDioryProps,
+  IDiographObject,
+  ILinkObject,
+} from '../types'
 
 import { Diory } from '../diory/diory'
 
@@ -88,21 +95,17 @@ class Diograph implements IDiograph {
     delete this.diograph[dioryObject.id]
   }
 
-  addDioryLink = (dioryObject: IDioryObject, linkedDioryObject: IDioryObject): IDiory => {
+  addDioryLink = (dioryObject: IDioryObject, linkObject: ILinkObject): IDiory => {
     throwErrorIfNotFound('addDioryLink:diory', dioryObject.id, Object.keys(this.diograph))
-    throwErrorIfNotFound(
-      'addDioryLink:linkedDiory',
-      linkedDioryObject.id,
-      Object.keys(this.diograph),
-    )
+    throwErrorIfNotFound('addDioryLink:linkedDiory', linkObject.id, Object.keys(this.diograph))
 
-    return this.getDiory(dioryObject).addLink(linkedDioryObject)
+    return this.getDiory(dioryObject).addLink(linkObject)
   }
 
-  removeDioryLink = (dioryObject: IDioryObject, linkedDioryObject: IDioryObject): IDiory => {
+  removeDioryLink = (dioryObject: IDioryObject, linkObject: ILinkObject): IDiory => {
     throwErrorIfNotFound('removeDioryLink:diory', dioryObject.id, Object.keys(this.diograph))
 
-    return this.getDiory(dioryObject).removeLink(linkedDioryObject)
+    return this.getDiory(dioryObject).removeLink(linkObject)
   }
 
   toObject = (): IDiographObject => {

--- a/diograph/diograph.ts
+++ b/diograph/diograph.ts
@@ -18,6 +18,7 @@ class Diograph implements IDiograph {
   }
 
   initialise = (diograph: IDiographObject): IDiograph => {
+    validateDiograph(diograph)
     Object.entries(diograph).forEach(([key, dioryObject]) => {
       try {
         this.diograph[key] = new Diory(dioryObject)

--- a/diograph/diograph.ts
+++ b/diograph/diograph.ts
@@ -49,6 +49,7 @@ class Diograph implements IDiograph {
     return this
   }
 
+  // FIXME: Only dioryId is used in the implementation
   getDiory = (dioryObject: IDioryObject): IDiory => {
     throwErrorIfNotFound('getDiory', dioryObject.id, Object.keys(this.diograph))
 
@@ -61,7 +62,31 @@ class Diograph implements IDiograph {
     return diory
   }
 
+  addRootDiory = (dioryObject?: IDioryProps | IDioryObject): IDiory => {
+    const defaultRootDiory = {
+      id: '/',
+      image:
+        'data:image/jpeg;base64,/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAFoAWgDASIAAhEBAxEB/8QAGwABAQADAQEBAAAAAAAAAAAAAAQBAwUCBgf/xAAzEAEAAQIDBgMIAQQDAAAAAAAAAQISAxETBGFikZLRFVFxBSExQVJTgbHwBiIyM3Khwf/EABkBAQADAQEAAAAAAAAAAAAAAAAEBgcBBf/EACwRAQABAwAJBAICAwAAAAAAAAABAgMRBAUGEhNRcrHBISQ0cTOhMTJBgZH/2gAMAwEAAhEDEQA/AP1EBly7AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZmYAZmYAZmYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABThU4kzONF1Pyp+XrPmNdeJbOSybLWaLumTNcZxTMx95iPLxde3KqNGjdnGZx+pbtDZvsYfSaGzfYw+lPrbzWaPuRyU3elRobN9jD6TQ2b7GH0p9Y1t7m5HI3pUaGzfYw+lidn2fL+3Dpon5VUe6YaNbea29yq1TVG7VGYdiuqmcxLbTnllV75j3ZsteHiU1ZxdGcT74e7o845sg06zwdJuW4jERM/8AM+jQ9FucSzRXM5zEdmRi6POOZdHnHNFSGRi6POObMTE/CQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbcHZ8TGiZoiMo+cy8YvszaK65mKsKI3zPZdslWWBTHq3XtM1DqqzotqjSac71VMZ/3iVG1trC7fuVWKsbtM9vRyPCdp+vC5z2PCdp+vC5z2de8vWF4+XI8J2n68LnPY8J2n68LnPZ17y8MuR4TtP14XOex4TtP14XOezr3l4Zcar2Nj1/5TgVevv8A/HnwPF8tn/n4du8vHcuJ4Hi+Wz/z8HgeL5bP/Pw7d5e4ZlxPA8Xy2f8An4Zj2LjUznRODTPnTMxP6dq8vcqpiqN2qMw7Fc0zmJQ07FjxRF1k1Ze/Kfin9fi617mY3+7E/wCUs+2h1Po+g0U3bGYzOMftb9TayvaXVVbu/wCIeAFVWAAAAAAAAAAAAAAAAAAAAAAAAAAAABTg15YcQ93pYryjI1Gwarj2Vnpp7QzfT591c6p7qry9LqGon4RMqry9LqGoYMqry9LqGoYMqry9LqGoYMqry9LqGoYMqry9LqGoYMqr0tc54lU7zUec85mVQ2w+Pb6vCx7N/mr+vIAz9cAAAAAAAAAAAAAAAAAAAAAAAAAAAAGnEqyrmHm/e1bRXljVR6NWo2PVceys9NPaGbaf8q51T3VX7y/el1DUTsIiq/eX70uoahgVX7y/el1DUMCq/eX70uoahgVX7y/el1DUMCq/eX70uoahgVXt9E50xLnai/BnPCp9FQ2x+Pb6vErHs3+av68vYDPVxAAAAAAAAAAAAAAAAAAAAAAAAAAAAcvbastprj0/TRex7Sqy23Ej0/Sa9suqo9lZ6ae0M00/5V3qnuqvL0t5en4RFV5elvLzAqvL0t5eYFV5elvLzAqvL0t5eYFV5elvLzAqvdbZZzwMOeGHz97v7FOey4U8MKdtl8a31eJWTZr81f15bgGeLkAAAAAAAAAAAAAAAAAAAAAAAAAAAA+c9r1Ze0MWPT9I72/+oIxMLb6666KtOuItqimZj4fD3fNzNaOLpns2LVF63VoNnFUf1iP55R6s31jarjSrmYn+091l5ej1o4umexrRxdM9no8SjnCFuVcll5ej1o4umexrRxdM9jiUc4NyrksvL0etHF0z2NaOLpnscSjnBuVcll5ej1o4umexrRxdM9jiUc4NyrksvL0etHF0z2NaOLpnscSjnBuVcll5ej1o4umexrRxdM9jiUc4NyrksvfT+z5z2LAngh8bTiTVVFNFOJVVPwppomZn/p9nsOHXhbHg0YkZV00REx5Spu2V2ibFuiJjOc/pZdm7dcXa6pj0x5bwGfLgAAAAAAAAAAAAAAAAAAAAAAAAAAAAHMAOZzADmcwA5nMAOZzADmcwA5nMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAf/Z',
+      text: 'Root',
+      created: new Date().toISOString(),
+      modified: new Date().toISOString(),
+    }
+    return this.addDiory(dioryObject || defaultRootDiory, '/')
+  }
+
+  addDioryAndLink = (dioryObject: IDioryObject, fromDioryLinkObject?: ILinkObject): IDiory => {
+    const diory = this.addDiory(dioryObject)
+
+    this.addDioryLink(fromDioryLinkObject || { id: '/' }, diory)
+
+    return diory
+  }
+
   addDiory = (dioryObject: IDioryProps | IDioryObject, key?: string): IDiory => {
+    if (this.isEmptyDiograph()) {
+      this.addRootDiory()
+    }
+
     if (key) {
       const diory: IDiory =
         'id' in dioryObject && this.diograph[dioryObject.id]
@@ -76,7 +101,7 @@ class Diograph implements IDiograph {
     }
 
     if ('id' in dioryObject) {
-      throwErrorIfAlreadyExists('updateDiory', dioryObject.id, Object.keys(this.diograph))
+      throwErrorIfAlreadyExists('addDiory', dioryObject.id, Object.keys(this.diograph))
     }
 
     const diory: IDiory = new Diory(dioryObject)
@@ -95,6 +120,7 @@ class Diograph implements IDiograph {
     delete this.diograph[dioryObject.id]
   }
 
+  // FIXME: Only dioryId is used from the dioryObject
   addDioryLink = (dioryObject: IDioryObject, linkObject: ILinkObject): IDiory => {
     throwErrorIfNotFound('addDioryLink:diory', dioryObject.id, Object.keys(this.diograph))
     throwErrorIfNotFound('addDioryLink:linkedDiory', linkObject.id, Object.keys(this.diograph))
@@ -133,6 +159,13 @@ class Diograph implements IDiograph {
   saveDiograph = async (roomClient: RoomClient) => {
     validateDiograph(JSON.parse(this.toJson()))
     await roomClient.saveDiograph(this.toJson())
+  }
+
+  isEmptyDiograph = (): boolean => {
+    if (this.diograph === undefined) {
+      throw new Error('Undefined diograph is not an empty diograph')
+    }
+    return Object.keys(this.diograph).length === 0
   }
 }
 

--- a/diograph/diograph.ts
+++ b/diograph/diograph.ts
@@ -77,14 +77,14 @@ class Diograph implements IDiograph {
   addDioryAndLink = (dioryObject: IDioryObject, fromDioryLinkObject?: ILinkObject): IDiory => {
     const diory = this.addDiory(dioryObject)
 
-    this.addDioryLink(fromDioryLinkObject || { id: '/' }, diory)
+    this.addDioryLink(fromDioryLinkObject || { id: '/' }, { id: diory.id })
 
     return diory
   }
 
   addDiory = (dioryObject: IDioryProps | IDioryObject, key?: string): IDiory => {
-    if (this.isEmptyDiograph()) {
-      this.addRootDiory()
+    if (key !== '/' && this.isEmptyDiograph()) {
+      throw new Error('addDiory: Diograph is empty. Use addRootDiory() to add root diory')
     }
 
     if (key) {

--- a/diosphere/connection.spec.ts
+++ b/diosphere/connection.spec.ts
@@ -12,9 +12,17 @@ const roomObject: RoomObject = {
           '/Generic content/some-video.mov',
       },
       diograph: {
+        '/': {
+          id: '/',
+          text: 'root-diory',
+          created: '2022-06-01T07:30:07.991Z',
+          modified: '2022-06-01T07:30:08.003Z',
+        },
         'some-id': {
           id: 'some-id',
           text: 'some-diory',
+          created: '2022-06-01T07:30:07.991Z',
+          modified: '2022-06-01T07:30:08.003Z',
         },
       },
     },

--- a/diosphere/connection.spec.ts
+++ b/diosphere/connection.spec.ts
@@ -58,8 +58,7 @@ describe('Connection', () => {
   })
 
   it('builds from object', () => {
-    const duplicateConnection = new Connection(new MockLocalClient())
-    duplicateConnection.initiateConnection(connection.toObject())
+    const duplicateConnection = new Connection(new MockLocalClient(), connection.toObject())
     expect(duplicateConnection.toObject()).toEqual(connection.toObject())
   })
 

--- a/diosphere/connection.ts
+++ b/diosphere/connection.ts
@@ -16,15 +16,14 @@ class Connection {
   diograph: IDiograph = new Diograph()
   client: ConnectionClient
 
-  constructor(connectionClient: ConnectionClient) {
+  constructor(connectionClient: ConnectionClient, connectionData?: ConnectionData) {
     this.address = connectionClient.address // full connection address
     this.contentClientType = connectionClient.type
     this.client = connectionClient
-  }
 
-  initiateConnection({ contentUrls = {}, diograph = {} }: ConnectionData) {
+    const { contentUrls, diograph } = connectionData || { contentUrls: {}, diograph: {} }
     this.contentUrls = contentUrls || {}
-    if (diograph && Object.keys(diograph).length) {
+    if (diograph) {
       this.diograph.initialise(diograph)
     }
   }

--- a/diosphere/connection.ts
+++ b/diosphere/connection.ts
@@ -28,9 +28,9 @@ class Connection {
     }
   }
 
-  getInternalPath = (contentUrl: string) => {
-    if (this.contentUrls[contentUrl]) {
-      return join(this.address, this.contentUrls[contentUrl])
+  getInternalPath = (contentId: string) => {
+    if (this.contentUrls[contentId]) {
+      return join(this.address, this.contentUrls[contentId])
     }
   }
 
@@ -49,17 +49,22 @@ class Connection {
     return contentId
   }
 
-  addContentUrl = (contentId: string, contentUrl?: string) => {
-    this.contentUrls[contentId] = contentUrl || contentId
+  addContentUrl = (contentId: string, contentInternalUrl?: string) => {
+    this.contentUrls[contentId] = contentInternalUrl || contentId
   }
 
-  // BUG: Doesn't remove contentUrl from connection!!!
-  deleteContent = async (contentUrl: string) => {
-    const filePath: string | undefined = this.getInternalPath(contentUrl)
+  removeContentUrl = (contentId: string) => {
+    delete this.contentUrls[contentId]
+  }
+
+  deleteContent = async (contentId: string) => {
+    const filePath: string | undefined = this.getInternalPath(contentId)
     if (!filePath) {
-      throw new Error('Nothing found with that contentUrl!')
+      throw new Error('Nothing found with that contentId!')
     }
-    return this.client.deleteItem(filePath)
+    return this.client.deleteItem(filePath).then(() => {
+      this.removeContentUrl(contentId)
+    })
   }
 
   deleteConnection = async () => {
@@ -74,9 +79,6 @@ class Connection {
   }
 
   toObject = (): ConnectionData => ({
-    // TODO: Make some kind of exception for relative paths (for demo-content-room which can't have absolute paths...)
-    // address: roomAddress ? makeRelative(roomAddress, this.address) : this.address,
-    // - but connection shouldn't know anything about the room...
     address: this.address,
     contentClientType: this.contentClientType,
     contentUrls: this.contentUrls,

--- a/diosphere/room.spec.ts
+++ b/diosphere/room.spec.ts
@@ -118,15 +118,17 @@ describe('Room', () => {
 
   beforeEach(async () => {
     const mockRoomClient: any = {
-      readRoomJson: () => roomJsonContents,
-      readDiograph: () => diographContents,
+      readRoomJson: async () => roomJsonContents,
+      readDiograph: async () => diographContents,
+      saveDiograph: async () => true,
+      saveRoomJson: async () => true,
       client: () => {
         return new MockLocalClient()
       },
     }
     unloadedRoom = new Room(mockRoomClient)
     room = new Room(mockRoomClient)
-    await room.loadRoom({
+    await room.loadOrInitiateRoom({
       LocalClient: { clientConstructor: MockLocalClient },
       S3Client: { clientConstructor: MockS3Client },
     })

--- a/diosphere/room.spec.ts
+++ b/diosphere/room.spec.ts
@@ -11,6 +11,12 @@ const roomJsonContents = JSON.stringify({
           '/Generic content/some-video.mov',
       },
       diograph: {
+        '/': {
+          id: '/',
+          text: 'root-diory',
+          created: '2022-06-01T07:30:07.991Z',
+          modified: '2022-06-01T07:30:08.003Z',
+        },
         '/Generic content/some-video.mov': {
           id: '/Generic content/some-video.mov',
           text: 'some-video.mov',
@@ -37,6 +43,12 @@ const roomJsonContents = JSON.stringify({
         bafkreihoednm4s2g4vpame3mweewfq5of3hks2mbmkvoksxg3z4rhmweeu: '/my-pic.jpg',
       },
       diograph: {
+        '/': {
+          id: '/',
+          text: 'root-diory',
+          created: '2022-06-01T07:30:07.991Z',
+          modified: '2022-06-01T07:30:08.003Z',
+        },
         '/my-pic.jpg': {
           id: '/my-pic.jpg',
           image: 'data:image/jpeg;base64,/9j/2wBDZ/9k=',
@@ -61,6 +73,12 @@ const roomJsonContents = JSON.stringify({
 })
 
 const diographContents = JSON.stringify({
+  '/': {
+    id: '/',
+    text: 'root-diory',
+    created: '2022-06-01T07:30:07.991Z',
+    modified: '2022-06-01T07:30:08.003Z',
+  },
   'some-id': {
     id: 'some-id',
     text: 'some-diory',

--- a/diosphere/room.ts
+++ b/diosphere/room.ts
@@ -248,7 +248,7 @@ class Room {
   toObject = (): RoomObject => {
     return {
       connections: this.connections.map((connection) => connection.toObject()),
-      diograph: this.diograph.toObject(),
+      // diograph: this.diograph.toObject(),
     }
   }
 

--- a/diosphere/room.ts
+++ b/diosphere/room.ts
@@ -2,6 +2,7 @@ import { RoomClient } from './roomClient'
 import { Diograph } from '../diograph/diograph'
 import { ConnectionClientList, ConnectionData, IDiographObject, RoomObject } from '../types'
 import { Connection, ContentNotFoundError } from './connection'
+import { validateConnectionData } from '../validator'
 
 class Room {
   diograph: Diograph
@@ -23,7 +24,101 @@ class Room {
     this.roomClientType = roomClient.client.constructor.name
   }
 
+  // Initiation needs connections & diographObject (or defaults are used)
+  // Loading needs room client to read the room.json
+  //    - validate room.json (or wherever the connections are stored)
+  loadOrInitiateRoom = async (
+    clients: ConnectionClientList,
+    connectionData?: ConnectionData[],
+    diographObject?: IDiographObject,
+  ) => {
+    const getConnectionData = async () => {
+      // 1. Get connections from arguments
+      if (connectionData) {
+        connectionData.forEach((connectionData: ConnectionData) => {
+          validateConnectionData(connectionData)
+        })
+        return connectionData
+      }
+
+      // 2. Load from room.json with roomClient
+      if (this.roomClient) {
+        const roomJsonContents = await this.roomClient.readRoomJson()
+        const roomJsonObject = JSON.parse(roomJsonContents)
+        roomJsonObject.connections.forEach((connectionData: ConnectionData) => {
+          validateConnectionData(connectionData)
+        })
+
+        return roomJsonObject.connections as ConnectionData[]
+      }
+
+      // 3. Error if connectionData not given as arguments or roomClient not defined
+      throw new Error(
+        "Can't loadOrInitiateRoom: no connections defined, use connections or roomClient",
+      )
+    }
+
+    // I. Load connections
+    const connectionDatas = await getConnectionData()
+    // this.connections = []
+    connectionDatas.forEach((connectionData: ConnectionData) => {
+      // a. Load client from availableClients
+      const clientData = clients[connectionData.contentClientType]
+      if (!clientData) {
+        throw new Error(
+          `loadOrInitiateRoom: Unknown clientType or incomplete availableClients data for ${connectionData.contentClientType}`,
+        )
+      }
+
+      // b. Create connection
+      // TODO: Combine initiateConnection with Connection constructor
+      const connection = new Connection(
+        new clientData.clientConstructor(connectionData.address, clientData.credentials),
+      )
+      connection.initiateConnection(connectionData)
+
+      // c. Add connection to room
+      this.addConnection(connection)
+    })
+
+    // II. Load diograph
+    const loadDiograph = async () => {
+      // 1. Get diograph from arguments
+      if (diographObject) {
+        this.diograph.initialise(diographObject)
+        return
+      }
+      // 2. Load diograph with roomClient (from diograph.json)
+      if (this.roomClient) {
+        this.diograph = new Diograph()
+        await this.diograph.loadDiograph(this.roomClient)
+        return
+      }
+      // 3. Use default diograph
+      const defaultDiographJson = {
+        '/': {
+          id: '/',
+          image:
+            'data:image/jpeg;base64,/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAFoAWgDASIAAhEBAxEB/8QAGwABAQADAQEBAAAAAAAAAAAAAAQBAwUCBgf/xAAzEAEAAQIDBgMIAQQDAAAAAAAAAQISAxETBGFikZLRFVFxBSExQVJTgbHwBiIyM3Khwf/EABkBAQADAQEAAAAAAAAAAAAAAAAEBgcBBf/EACwRAQABAwAJBAICAwAAAAAAAAABAgMRBAUGEhNRcrHBISQ0cTOhMTJBgZH/2gAMAwEAAhEDEQA/AP1EBly7AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZmYAZmYAZmYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABThU4kzONF1Pyp+XrPmNdeJbOSybLWaLumTNcZxTMx95iPLxde3KqNGjdnGZx+pbtDZvsYfSaGzfYw+lPrbzWaPuRyU3elRobN9jD6TQ2b7GH0p9Y1t7m5HI3pUaGzfYw+lidn2fL+3Dpon5VUe6YaNbea29yq1TVG7VGYdiuqmcxLbTnllV75j3ZsteHiU1ZxdGcT74e7o845sg06zwdJuW4jERM/8AM+jQ9FucSzRXM5zEdmRi6POOZdHnHNFSGRi6POObMTE/CQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbcHZ8TGiZoiMo+cy8YvszaK65mKsKI3zPZdslWWBTHq3XtM1DqqzotqjSac71VMZ/3iVG1trC7fuVWKsbtM9vRyPCdp+vC5z2PCdp+vC5z2de8vWF4+XI8J2n68LnPY8J2n68LnPZ17y8MuR4TtP14XOex4TtP14XOezr3l4Zcar2Nj1/5TgVevv8A/HnwPF8tn/n4du8vHcuJ4Hi+Wz/z8HgeL5bP/Pw7d5e4ZlxPA8Xy2f8An4Zj2LjUznRODTPnTMxP6dq8vcqpiqN2qMw7Fc0zmJQ07FjxRF1k1Ze/Kfin9fi617mY3+7E/wCUs+2h1Po+g0U3bGYzOMftb9TayvaXVVbu/wCIeAFVWAAAAAAAAAAAAAAAAAAAAAAAAAAAABTg15YcQ93pYryjI1Gwarj2Vnpp7QzfT591c6p7qry9LqGon4RMqry9LqGoYMqry9LqGoYMqry9LqGoYMqry9LqGoYMqry9LqGoYMqr0tc54lU7zUec85mVQ2w+Pb6vCx7N/mr+vIAz9cAAAAAAAAAAAAAAAAAAAAAAAAAAAAGnEqyrmHm/e1bRXljVR6NWo2PVceys9NPaGbaf8q51T3VX7y/el1DUTsIiq/eX70uoahgVX7y/el1DUMCq/eX70uoahgVX7y/el1DUMCq/eX70uoahgVXt9E50xLnai/BnPCp9FQ2x+Pb6vErHs3+av68vYDPVxAAAAAAAAAAAAAAAAAAAAAAAAAAAAcvbastprj0/TRex7Sqy23Ej0/Sa9suqo9lZ6ae0M00/5V3qnuqvL0t5en4RFV5elvLzAqvL0t5eYFV5elvLzAqvL0t5eYFV5elvLzAqvdbZZzwMOeGHz97v7FOey4U8MKdtl8a31eJWTZr81f15bgGeLkAAAAAAAAAAAAAAAAAAAAAAAAAAAA+c9r1Ze0MWPT9I72/+oIxMLb6666KtOuItqimZj4fD3fNzNaOLpns2LVF63VoNnFUf1iP55R6s31jarjSrmYn+091l5ej1o4umexrRxdM9no8SjnCFuVcll5ej1o4umexrRxdM9jiUc4NyrksvL0etHF0z2NaOLpnscSjnBuVcll5ej1o4umexrRxdM9jiUc4NyrksvL0etHF0z2NaOLpnscSjnBuVcll5ej1o4umexrRxdM9jiUc4NyrksvfT+z5z2LAngh8bTiTVVFNFOJVVPwppomZn/p9nsOHXhbHg0YkZV00REx5Spu2V2ibFuiJjOc/pZdm7dcXa6pj0x5bwGfLgAAAAAAAAAAAAAAAAAAAAAAAAAAAAHMAOZzADmcwA5nMAOZzADmcwA5nMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAf/Z',
+          text: 'Root',
+          created: '2021-09-29T08:00:00.000Z',
+          modified: '2021-09-29T08:00:00.000Z',
+        },
+      }
+      this.diograph.initialise(defaultDiographJson)
+    }
+
+    await loadDiograph()
+
+    // III. Save room
+    if (this.roomClient) {
+      await this.saveRoom()
+    }
+  }
+
   loadRoom = async (clients: ConnectionClientList) => {
+    console.log('DEPRECATED: loadRoom is deprecated, use loadOrInitiateRoom instead')
+
     if (!this.roomClient) {
       throw new Error("Can't loadRoom: no roomClient defined, use defineRoomClient to define it")
     }
@@ -54,6 +149,8 @@ class Room {
     connections?: ConnectionData[],
     diographObject?: IDiographObject,
   ) => {
+    console.log('DEPRECATED: loadRoom is deprecated, use loadOrInitiateRoom instead')
+
     // Connections
     if (connections) {
       this.connections = []
@@ -75,6 +172,8 @@ class Room {
         image:
           'data:image/jpeg;base64,/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAFoAWgDASIAAhEBAxEB/8QAGwABAQADAQEBAAAAAAAAAAAAAAQBAwUCBgf/xAAzEAEAAQIDBgMIAQQDAAAAAAAAAQISAxETBGFikZLRFVFxBSExQVJTgbHwBiIyM3Khwf/EABkBAQADAQEAAAAAAAAAAAAAAAAEBgcBBf/EACwRAQABAwAJBAICAwAAAAAAAAABAgMRBAUGEhNRcrHBISQ0cTOhMTJBgZH/2gAMAwEAAhEDEQA/AP1EBly7AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZmYAZmYAZmYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABThU4kzONF1Pyp+XrPmNdeJbOSybLWaLumTNcZxTMx95iPLxde3KqNGjdnGZx+pbtDZvsYfSaGzfYw+lPrbzWaPuRyU3elRobN9jD6TQ2b7GH0p9Y1t7m5HI3pUaGzfYw+lidn2fL+3Dpon5VUe6YaNbea29yq1TVG7VGYdiuqmcxLbTnllV75j3ZsteHiU1ZxdGcT74e7o845sg06zwdJuW4jERM/8AM+jQ9FucSzRXM5zEdmRi6POOZdHnHNFSGRi6POObMTE/CQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbcHZ8TGiZoiMo+cy8YvszaK65mKsKI3zPZdslWWBTHq3XtM1DqqzotqjSac71VMZ/3iVG1trC7fuVWKsbtM9vRyPCdp+vC5z2PCdp+vC5z2de8vWF4+XI8J2n68LnPY8J2n68LnPZ17y8MuR4TtP14XOex4TtP14XOezr3l4Zcar2Nj1/5TgVevv8A/HnwPF8tn/n4du8vHcuJ4Hi+Wz/z8HgeL5bP/Pw7d5e4ZlxPA8Xy2f8An4Zj2LjUznRODTPnTMxP6dq8vcqpiqN2qMw7Fc0zmJQ07FjxRF1k1Ze/Kfin9fi617mY3+7E/wCUs+2h1Po+g0U3bGYzOMftb9TayvaXVVbu/wCIeAFVWAAAAAAAAAAAAAAAAAAAAAAAAAAAABTg15YcQ93pYryjI1Gwarj2Vnpp7QzfT591c6p7qry9LqGon4RMqry9LqGoYMqry9LqGoYMqry9LqGoYMqry9LqGoYMqry9LqGoYMqr0tc54lU7zUec85mVQ2w+Pb6vCx7N/mr+vIAz9cAAAAAAAAAAAAAAAAAAAAAAAAAAAAGnEqyrmHm/e1bRXljVR6NWo2PVceys9NPaGbaf8q51T3VX7y/el1DUTsIiq/eX70uoahgVX7y/el1DUMCq/eX70uoahgVX7y/el1DUMCq/eX70uoahgVXt9E50xLnai/BnPCp9FQ2x+Pb6vErHs3+av68vYDPVxAAAAAAAAAAAAAAAAAAAAAAAAAAAAcvbastprj0/TRex7Sqy23Ej0/Sa9suqo9lZ6ae0M00/5V3qnuqvL0t5en4RFV5elvLzAqvL0t5eYFV5elvLzAqvL0t5eYFV5elvLzAqvdbZZzwMOeGHz97v7FOey4U8MKdtl8a31eJWTZr81f15bgGeLkAAAAAAAAAAAAAAAAAAAAAAAAAAAA+c9r1Ze0MWPT9I72/+oIxMLb6666KtOuItqimZj4fD3fNzNaOLpns2LVF63VoNnFUf1iP55R6s31jarjSrmYn+091l5ej1o4umexrRxdM9no8SjnCFuVcll5ej1o4umexrRxdM9jiUc4NyrksvL0etHF0z2NaOLpnscSjnBuVcll5ej1o4umexrRxdM9jiUc4NyrksvL0etHF0z2NaOLpnscSjnBuVcll5ej1o4umexrRxdM9jiUc4NyrksvfT+z5z2LAngh8bTiTVVFNFOJVVPwppomZn/p9nsOHXhbHg0YkZV00REx5Spu2V2ibFuiJjOc/pZdm7dcXa6pj0x5bwGfLgAAAAAAAAAAAAAAAAAAAAAAAAAAAAHMAOZzADmcwA5nMAOZzADmcwA5nMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAf/Z',
         text: 'Root',
+        created: '2021-09-29T08:00:00.000Z',
+        modified: '2021-09-29T08:00:00.000Z',
       },
     }
 

--- a/diosphere/room.ts
+++ b/diosphere/room.ts
@@ -43,8 +43,15 @@ class Room {
 
       // 2. Load from room.json with roomClient
       if (this.roomClient) {
-        const roomJsonContents = await this.roomClient.readRoomJson()
+        let roomJsonContents
+        try {
+          roomJsonContents = await this.roomClient.readRoomJson()
+        } catch {
+          await this.saveRoom()
+          roomJsonContents = await this.roomClient.readRoomJson()
+        }
         const roomJsonObject = JSON.parse(roomJsonContents)
+
         roomJsonObject.connections.forEach((connectionData: ConnectionData) => {
           validateConnectionData(connectionData)
         })
@@ -59,7 +66,7 @@ class Room {
     }
 
     // I. Load connections
-    const connectionDatas = await getConnectionData()
+    const connectionDatas = (await getConnectionData()) || []
     // this.connections = []
     connectionDatas.forEach((connectionData: ConnectionData) => {
       // a. Load client from availableClients

--- a/diosphere/room.ts
+++ b/diosphere/room.ts
@@ -71,11 +71,10 @@ class Room {
       }
 
       // b. Create connection
-      // TODO: Combine initiateConnection with Connection constructor
       const connection = new Connection(
         new clientData.clientConstructor(connectionData.address, clientData.credentials),
+        connectionData,
       )
-      connection.initiateConnection(connectionData)
 
       // c. Add connection to room
       this.addConnection(connection)
@@ -134,8 +133,8 @@ class Room {
       const clientData = clients[connectionData.contentClientType]
       const connection = new Connection(
         new clientData.clientConstructor(connectionData.address, clientData.credentials),
+        connectionData,
       )
-      connection.initiateConnection(connectionData)
       this.addConnection(connection)
     })
 
@@ -158,8 +157,8 @@ class Room {
         const clientData = clients[connectionData.contentClientType]
         const connection = new Connection(
           new clientData.clientConstructor(connectionData.address, clientData.credentials),
+          connectionData,
         )
-        connection.initiateConnection(connectionData)
         this.addConnection(connection)
       })
     }

--- a/index.ts
+++ b/index.ts
@@ -4,3 +4,9 @@ export { Diory } from './diory/diory'
 export { Room } from './diosphere/room'
 export { Connection } from './diosphere/connection'
 export { RoomClient } from './diosphere/roomClient'
+
+export {
+  constructAndLoadRoom,
+  constructRoom,
+  getClientAndVerify,
+} from './utils/constructAndLoadRoom'

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ export { Connection } from './diosphere/connection'
 export { RoomClient } from './diosphere/roomClient'
 
 export {
+  constructAndLoadRoomWithNativeConnection,
   constructAndLoadRoom,
   constructRoom,
   getClientAndVerify,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diograph/diograph",
-  "version": "0.2.4-rc1",
+  "version": "0.3.0-rc1",
   "main": "dist/index.js",
   "types": "dist/**/*.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diograph/diograph",
-  "version": "0.3.0-rc1",
+  "version": "0.2.5-rc1",
   "main": "dist/index.js",
   "types": "dist/**/*.d.ts",
   "exports": {

--- a/types.ts
+++ b/types.ts
@@ -52,6 +52,8 @@ export interface IDiograph {
   resetDiograph: () => IDiograph
   getDiory: (dioryObject: IDioryObject) => IDiory
   addDiory: (dioryProps: IDioryProps | IDioryObject | IDiory, key?: string) => IDiory
+  addRootDiory: (dioryObject?: IDioryProps | IDioryObject) => IDiory
+  addDioryAndLink: (dioryObject: IDioryObject, fromDioryLinkObject?: ILinkObject) => IDiory
   updateDiory: (dioryObject: IDioryObject) => IDiory
   removeDiory: (dioryObject: IDioryObject) => void
   addDioryLink: (dioryObject: IDioryObject, linkedDioryObject: IDioryObject) => IDiory
@@ -59,6 +61,7 @@ export interface IDiograph {
   toObject: () => IDiographObject
   loadDiograph: (roomClient: RoomClient) => Promise<void>
   saveDiograph: (roomClient: RoomClient) => Promise<void>
+  isEmptyDiograph: () => boolean
 }
 
 // custom type, no validator...

--- a/types.ts
+++ b/types.ts
@@ -32,8 +32,8 @@ export interface IDioryObject extends IDioryProps {
 
 export interface IDiory extends IDioryObject {
   update: (dioryProps: IDioryProps, addOnly?: boolean) => IDiory
-  addLink: (linkedDioryObject: IDioryObject) => IDiory
-  removeLink: (linkedDioryObject: IDioryObject) => IDiory
+  addLink: (linkObject: ILinkObject) => IDiory
+  removeLink: (linkObject: ILinkObject) => IDiory
   toObject: () => IDioryObject
   toObjectWithoutImage: () => IDioryObject
 }

--- a/utils/constructAndLoadRoom.ts
+++ b/utils/constructAndLoadRoom.ts
@@ -37,6 +37,6 @@ export const constructAndLoadRoom = async (
   availableClients: ConnectionClientList,
 ): Promise<Room> => {
   const room = await constructRoom(address, roomClientType, availableClients)
-  await room.loadRoom(availableClients)
+  await room.loadOrInitiateRoom(availableClients)
   return room
 }

--- a/utils/constructAndLoadRoom.ts
+++ b/utils/constructAndLoadRoom.ts
@@ -1,3 +1,4 @@
+import { Connection } from '../diosphere/connection'
 import { Room } from '../diosphere/room'
 import { RoomClient } from '../diosphere/roomClient'
 import { ConnectionClient, ConnectionClientList, ConnectionData, IDiographObject } from '../types'
@@ -40,5 +41,33 @@ export const constructAndLoadRoom = async (
 ): Promise<Room> => {
   const room = await constructRoom(address, roomClientType, availableClients)
   await room.loadOrInitiateRoom(availableClients, connectionData, diographObject)
+  return room
+}
+
+export const constructAndLoadRoomWithNativeConnection = async (
+  address: string,
+  roomClientType: string,
+  availableClients: ConnectionClientList,
+  connectionData?: ConnectionData[],
+  diographObject?: IDiographObject,
+): Promise<Room> => {
+  const room = await constructAndLoadRoom(
+    address,
+    roomClientType,
+    availableClients,
+    connectionData,
+    diographObject,
+  )
+  const nativeConnection = new Connection(
+    await getClientAndVerify(
+      `${
+        address[address.length - 1] === '/' ? address.slice(0, address.length - 1) : address
+      }/Diory Content`,
+      roomClientType,
+      availableClients,
+    ),
+  )
+  room.addConnection(nativeConnection)
+
   return room
 }

--- a/utils/constructAndLoadRoom.ts
+++ b/utils/constructAndLoadRoom.ts
@@ -1,6 +1,6 @@
 import { Room } from '../diosphere/room'
 import { RoomClient } from '../diosphere/roomClient'
-import { ConnectionClient, ConnectionClientList } from '../types'
+import { ConnectionClient, ConnectionClientList, ConnectionData, IDiographObject } from '../types'
 
 export const getClientAndVerify = async (
   address: string,
@@ -35,8 +35,10 @@ export const constructAndLoadRoom = async (
   address: string,
   roomClientType: string,
   availableClients: ConnectionClientList,
+  connectionData?: ConnectionData[],
+  diographObject?: IDiographObject,
 ): Promise<Room> => {
   const room = await constructRoom(address, roomClientType, availableClients)
-  await room.loadOrInitiateRoom(availableClients)
+  await room.loadOrInitiateRoom(availableClients, connectionData, diographObject)
   return room
 }

--- a/utils/constructAndLoadRoom.ts
+++ b/utils/constructAndLoadRoom.ts
@@ -1,0 +1,42 @@
+import { Room } from '../diosphere/room'
+import { RoomClient } from '../diosphere/roomClient'
+import { ConnectionClient, ConnectionClientList } from '../types'
+
+export const getClientAndVerify = async (
+  address: string,
+  clientType: string,
+  availableClients: ConnectionClientList,
+): Promise<ConnectionClient> => {
+  const clientData = availableClients[clientType]
+
+  if (!clientData) {
+    throw new Error(
+      `getClientAndVerify: Unknown clientType or incomplete availableClients data for ${clientType}`,
+    )
+  }
+
+  const client = new clientData.clientConstructor(address, clientData.credentials)
+  await client.verify()
+
+  return client
+}
+
+export const constructRoom = async (
+  address: string,
+  roomClientType: string,
+  availableClients: ConnectionClientList,
+): Promise<Room> => {
+  const client = await getClientAndVerify(address, roomClientType, availableClients)
+  const roomClient = new RoomClient(client)
+  return new Room(roomClient)
+}
+
+export const constructAndLoadRoom = async (
+  address: string,
+  roomClientType: string,
+  availableClients: ConnectionClientList,
+): Promise<Room> => {
+  const room = await constructRoom(address, roomClientType, availableClients)
+  await room.loadRoom(availableClients)
+  return room
+}

--- a/validator-fixtures.ts
+++ b/validator-fixtures.ts
@@ -25,6 +25,12 @@ export const connectionData: { connections: ConnectionData[] } = {
           '/Scouts BSA International/PIXNIO-53555-1782x1188.jpeg',
       },
       diograph: {
+        '/': {
+          id: '/',
+          text: 'root-diory',
+          created: '2022-06-01T07:30:07.991Z',
+          modified: '2022-06-01T07:30:08.003Z',
+        },
         diory13: {
           id: 'diory13',
           text: 'Diory 13',
@@ -70,6 +76,12 @@ export const connectionDataWithId: { connections: ConnectionData[] } = {
           '/Scouts BSA International/PIXNIO-53555-1782x1188.jpeg',
       },
       diograph: {
+        '/': {
+          id: '/',
+          text: 'root-diory',
+          created: '2022-06-01T07:30:07.991Z',
+          modified: '2022-06-01T07:30:08.003Z',
+        },
         diory13: {
           id: 'diory13',
           text: 'Diory 13',

--- a/validator.ts
+++ b/validator.ts
@@ -1,5 +1,5 @@
 import Ajv from 'ajv'
-import { CIDMapping, IDiographObject } from './types'
+import { CIDMapping, ConnectionData, IDiographObject, RoomConfigData } from './types'
 const ajv = new Ajv({ allErrors: true })
 // const addFormats = require('ajv-formats')
 // addFormats(ajv)
@@ -70,8 +70,7 @@ const diographSchema = {
   $schema: 'http://json-schema.org/draft-07/schema#',
   type: 'object',
   additionalProperties: diorySchema,
-  // TODO: Make '/' required
-  // required: ['/'],
+  required: ['/'],
 }
 
 const validateDiograph = (diographObject: IDiographObject) => {
@@ -105,7 +104,7 @@ const roomConfigDataSchema = {
 // const connectionConfigDataSchema = roomConfigDataSchema;
 
 // type: RoomConfigData
-const validateRoomConfigData = (configDataObject: object) => {
+const validateRoomConfigData = (configDataObject: RoomConfigData) => {
   validate(roomConfigDataSchema, configDataObject)
 }
 
@@ -126,7 +125,7 @@ const connectionDataSchema = {
   },
 }
 
-const validateConnectionData = (connectionDataObject: object) => {
+const validateConnectionData = (connectionDataObject: ConnectionData) => {
   validate(connectionDataSchema, connectionDataObject)
 }
 

--- a/validator.ts
+++ b/validator.ts
@@ -124,13 +124,19 @@ const connectionDataSchema = {
     id: { type: 'string' },
     address: { type: 'string' },
     clientType: { type: 'string', enum: clientTypeEnum },
-    diograph: diographSchema,
-    contentUrls: cidMappingSchema,
+    // diograph: diographSchema,
+    // contentUrls: cidMappingSchema,
   },
 }
 
 const validateConnectionData = (connectionDataObject: ConnectionData) => {
   validate(connectionDataSchema, connectionDataObject)
+  if (connectionDataObject.diograph && Object.keys(connectionDataObject.diograph).length > 0) {
+    validate(diographSchema, connectionDataObject.diograph)
+  }
+  if (connectionDataObject.contentUrls) {
+    validate(cidMappingSchema, connectionDataObject.contentUrls)
+  }
 }
 
 export {

--- a/validator.ts
+++ b/validator.ts
@@ -74,6 +74,10 @@ const diographSchema = {
 }
 
 const validateDiograph = (diographObject: IDiographObject) => {
+  if (Object.keys(diographObject).length === 0) {
+    console.log('WARN: Empty diograph passed as valid')
+    return
+  }
   validate(diographSchema, diographObject)
 }
 

--- a/validator.ts
+++ b/validator.ts
@@ -47,7 +47,7 @@ const diorySchema = {
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['@context', '@type', 'contentUrl', 'encodingFormat'],
+        required: ['@context', '@type', 'contentUrl'],
         properties: {
           '@context': { type: 'string' },
           '@type': { type: 'string' },


### PR DESCRIPTION
- validate all the diograph objects
  - ones given as arguments
  - ones read from diograph.json files
  - ones in ConnectionData
  - regard empty diographs (=`{}`) as valid
- new loadOrInitialiseRoom
  - DEPRECATE: loadRoom and initialiseRoom 
- queryDiograph() disabled because current implementation uses invalid diographs

- merge @diograph/utils to here
- new constructAndLoadRoomWithNativeConnection to replace CLI's createRoom

- addDiory() creates now root diory if diograph is empty
  - helper for checking if diograph is empty

- addDioryAndLink() links new diory to given diory or to root diory by default

- all kinds of minor bug fixes and minor validation changes